### PR TITLE
Extend final frame hold

### DIFF
--- a/gcc/README.md
+++ b/gcc/README.md
@@ -1,0 +1,28 @@
+# Native C Version
+
+This folder provides a native implementation of the ripple effect.
+The program uses OpenCV to read the images, generate frames, and calls
+`ffmpeg` to assemble the resulting MP4 videos.
+
+## Build
+
+Make sure the OpenCV development libraries are installed. On Debian/Ubuntu:
+
+```bash
+sudo apt-get install libopencv-dev
+```
+
+Compile with g++:
+
+```bash
+g++ -std=c++17 goutte.cpp `pkg-config --cflags --libs opencv4` -o goutte
+```
+
+## Usage
+
+```bash
+./goutte chemin/vers/dossier_images
+```
+
+Videos are written to the `result` folder with the same base name as the
+input image but with an `.mp4` extension.

--- a/gcc/goutte.cpp
+++ b/gcc/goutte.cpp
@@ -1,0 +1,142 @@
+#include <opencv2/opencv.hpp>
+#include <filesystem>
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+
+namespace fs = std::filesystem;
+
+void apply_ripple_effect(const std::string& image_path,
+                         const std::string& frame_folder,
+                         int duration = 5,
+                         int fps = 30,
+                         double max_amplitude = 7.0,
+                         int num_waves = 20)
+{
+    cv::Mat image_bgr = cv::imread(image_path, cv::IMREAD_COLOR);
+    if (image_bgr.empty()) {
+        std::cerr << "Cannot open image: " << image_path << std::endl;
+        return;
+    }
+    cv::Mat image;
+    cv::cvtColor(image_bgr, image, cv::COLOR_BGR2RGB);
+
+    int height = image.rows;
+    int width = image.cols;
+
+    int total_frames = duration * fps;
+    int hold_frames = static_cast<int>(0.2 * fps);
+
+    cv::Mat dx(height, width, CV_32F);
+    cv::Mat dy(height, width, CV_32F);
+    cv::Mat distance(height, width, CV_32F);
+    cv::Mat distance_safe(height, width, CV_32F);
+
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            float fx = static_cast<float>(x - width / 2);
+            float fy = static_cast<float>(y - height / 2);
+            dx.at<float>(y, x) = fx;
+            dy.at<float>(y, x) = fy;
+            float dist = std::sqrt(fx * fx + fy * fy);
+            distance.at<float>(y, x) = dist;
+            distance_safe.at<float>(y, x) = dist == 0.0f ? 1.0f : dist;
+        }
+    }
+
+    fs::create_directories(frame_folder);
+
+    for (int frame_num = 0; frame_num < total_frames; ++frame_num) {
+        cv::Mat distorted(image.rows, image.cols, image.type());
+
+        if (frame_num < hold_frames || frame_num >= total_frames - hold_frames) {
+            distorted = image.clone();
+        } else {
+            double time = static_cast<double>(frame_num) / fps;
+            double progress = static_cast<double>(frame_num - hold_frames) /
+                              (total_frames - 2 * hold_frames);
+            double dynamic_ripple_scale = 60.0 + 100.0 * progress;
+            double dynamic_damping = 300.0 + 700.0 * progress;
+            double dynamic_num_waves = num_waves * (1 - 0.5 * progress);
+            double wave_decay = 1 - progress;
+
+            for (int y = 0; y < height; ++y) {
+                for (int x = 0; x < width; ++x) {
+                    double angle_base = distance.at<float>(y, x) / dynamic_ripple_scale;
+                    double angle = angle_base -
+                                   time * (dynamic_num_waves * M_PI / duration);
+                    double intensity = max_amplitude * 3.0 * std::sin(angle) *
+                                       wave_decay *
+                                       std::exp(-distance.at<float>(y, x) /
+                                                dynamic_damping);
+                    double offset_dx = dx.at<float>(y, x) / distance_safe.at<float>(y, x) * intensity;
+                    double offset_dy = dy.at<float>(y, x) / distance_safe.at<float>(y, x) * intensity;
+                    int src_x = std::clamp(static_cast<int>(x + offset_dx), 0, width - 1);
+                    int src_y = std::clamp(static_cast<int>(y + offset_dy), 0, height - 1);
+                    distorted.at<cv::Vec3b>(y, x) = image.at<cv::Vec3b>(src_y, src_x);
+                }
+            }
+        }
+
+        std::ostringstream frame_name;
+        frame_name << frame_folder << "/frame_" << std::setw(4) << std::setfill('0')
+                   << frame_num << ".png";
+        cv::imwrite(frame_name.str(), distorted);
+    }
+}
+
+void assemble_video(const std::string& frame_folder,
+                    const std::string& output_video,
+                    int fps = 30)
+{
+    std::ostringstream cmd;
+    cmd << "ffmpeg -y -framerate " << fps
+        << " -i " << frame_folder << "/frame_%04d.png"
+        << " -c:v libx264 -pix_fmt yuv420p "
+        << output_video << " >/dev/null 2>&1";
+    std::system(cmd.str().c_str());
+}
+
+int main(int argc, char** argv)
+{
+    if (argc < 2) {
+        std::cout << "Usage: " << argv[0] << " image_directory" << std::endl;
+        return 1;
+    }
+    fs::path images_dir = argv[1];
+    if (!fs::is_directory(images_dir)) {
+        std::cerr << "Le chemin specifie n'est pas un dossier" << std::endl;
+        return 1;
+    }
+
+    fs::path result_dir = "result";
+    fs::create_directories(result_dir);
+
+    std::vector<fs::path> images;
+    for (const auto& entry : fs::directory_iterator(images_dir)) {
+        if (!entry.is_regular_file()) continue;
+        std::string ext = entry.path().extension().string();
+        std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+        if (ext == ".png" || ext == ".jpg" || ext == ".jpeg")
+            images.push_back(entry.path());
+    }
+    std::sort(images.begin(), images.end());
+
+    if (images.empty()) {
+        std::cerr << "Aucune image PNG ou JPG trouvee dans le dossier" << std::endl;
+        return 1;
+    }
+
+    for (const auto& image_path : images) {
+        std::string base_name = image_path.stem().string();
+        fs::path frame_folder = result_dir / (base_name + "_frames");
+        fs::path output_video = result_dir / (base_name + ".mp4");
+
+        apply_ripple_effect(image_path.string(), frame_folder.string());
+        assemble_video(frame_folder.string(), output_video.string());
+        std::cout << "Nom du fichier genere : " << output_video.filename().string() << std::endl;
+    }
+
+    return 0;
+}
+

--- a/goutte.py
+++ b/goutte.py
@@ -7,14 +7,28 @@ import numba
 from tqdm import tqdm
 from numba import njit, prange
 
-def apply_ripple_effect(image_path, output_folder, duration=5, fps=30, max_amplitude=7.0, num_waves=20):
+def apply_ripple_effect(
+    image_path,
+    output_folder,
+    duration=5,
+    fps=30,
+    max_amplitude=7.0,
+    num_waves=20,
+    hold_end_seconds=5,  # durée en secondes de l'arrêt sur image final
+):
     # Charger l'image avec OpenCV (préserve les couleurs sans conversion implicite)
     image_bgr = cv2.imread(image_path, cv2.IMREAD_COLOR)
     image_np = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
     height, width, _ = image_np.shape
 
-    total_frames = duration * fps
-    hold_frames = int(0.2 * fps)  # 0.5 seconde d'image stable
+    hold_start_frames = int(0.2 * fps)  # durée de l'image fixe au début
+    hold_end_frames = int(hold_end_seconds * fps)
+
+    ripple_frames = duration * fps - 2 * hold_start_frames
+    if ripple_frames < 0:
+        ripple_frames = 0
+
+    total_frames = hold_start_frames + ripple_frames + hold_end_frames
 
     # Pré-calculs
     y_indices, x_indices = np.indices((height, width))
@@ -29,12 +43,12 @@ def apply_ripple_effect(image_path, output_folder, duration=5, fps=30, max_ampli
     from tqdm import tqdm
 
     for frame_num in tqdm(range(total_frames), desc="Génération des frames", unit="frame"):
-        if frame_num < hold_frames or frame_num >= total_frames - hold_frames:
+        if frame_num < hold_start_frames or frame_num >= hold_start_frames + ripple_frames:
             # Image stable sans effet au début et à la fin
             distorted = image_np.copy()
         else:
-            time = frame_num / fps
-            progress = (frame_num - hold_frames) / (total_frames - 2 * hold_frames)
+            time = (frame_num - hold_start_frames) / fps
+            progress = (frame_num - hold_start_frames) / ripple_frames
 
             # Fréquence et portée de l'onde diminuent progressivement
             dynamic_ripple_scale = 60.0 + 100.0 * progress
@@ -95,15 +109,46 @@ def apply_displacement(image, src_y, src_x):
             output[y, x, 2] = image[src_y[y, x], src_x[y, x], 2]
     return output
 
-# Exemple d'utilisation :
+# Exemple d'utilisation modifié : le script prend maintenant en argument un
+# dossier contenant des images (PNG ou JPG). Pour chaque image trouvée, l'effet
+# goutte est appliqué et une vidéo MP4 est générée dans le dossier "result".
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage : python script.py chemin/image.png")
+        print("Usage : python script.py dossier_images")
         sys.exit(1)
 
-    input_image = sys.argv[1]
-    output_folder = "ripple_frames"
-    output_video = "ripple_output.mp4"
+    images_dir = sys.argv[1]
+    if not os.path.isdir(images_dir):
+        print("Le chemin spécifié n'est pas un dossier")
+        sys.exit(1)
 
-    apply_ripple_effect(input_image, output_folder, duration=5, fps=30, max_amplitude=7.0, num_waves=20)
-    assemble_video_from_frames(output_folder, output_video)
+    result_dir = "result"
+    os.makedirs(result_dir, exist_ok=True)
+
+    images = sorted(
+        [f for f in os.listdir(images_dir) if f.lower().endswith((".png", ".jpg", ".jpeg"))]
+    )
+
+    if not images:
+        print("Aucune image PNG ou JPG trouvée dans le dossier")
+        sys.exit(1)
+
+    for image_name in images:
+        input_image = os.path.join(images_dir, image_name)
+        base_name = os.path.splitext(image_name)[0]
+
+        frame_folder = os.path.join(result_dir, f"{base_name}_frames")
+        output_video = os.path.join(result_dir, base_name + ".mp4")
+
+        apply_ripple_effect(
+            input_image,
+            frame_folder,
+            duration=5,
+            fps=30,
+            max_amplitude=7.0,
+            num_waves=20,
+            hold_end_seconds=5,
+        )
+        assemble_video_from_frames(frame_folder, output_video)
+        # Affiche le nom du fichier vidéo généré
+        print(f"Nom du fichier généré : {os.path.basename(output_video)}")


### PR DESCRIPTION
## Summary
- allow `apply_ripple_effect` to specify final still duration
- keep the ripple duration the same but add a 5‑second freeze frame at the end
- update example usage accordingly

## Testing
- `python -m py_compile goutte.py`


------
https://chatgpt.com/codex/tasks/task_e_684ca8e01be08331a72b4e3f22652714